### PR TITLE
Make "model-free" discount function more robust

### DIFF
--- a/R/internal-utils.R
+++ b/R/internal-utils.R
@@ -95,3 +95,19 @@ validate_td_data <- function(data, required_columns) {
   }
   
 }
+
+initialize_discount_function <- function(disc_func, data) {
+  if ('init' %in% names(disc_func)) {
+    # Run init() and do some validation
+    disc_func <- disc_func$init(disc_func, data)
+    stopifnot(
+      is.list(disc_func$par_starts),
+      is.list(disc_func$par_lims),
+      all(names(disc_func$par_starts) == names(disc_func$par_lims)),
+      all(vapply(disc_func$par_lims, length, integer(1)) == 2),
+      is.function(disc_func$fn),
+      all(names(formals(disc_func$fn)) == c('data', 'p'))
+    )
+  }
+  return(disc_func)
+}

--- a/R/methods.R
+++ b/R/methods.R
@@ -47,7 +47,7 @@ ED50 <- function(mod, val_del = NULL) {
 #' @param ... Further arguments passed to `integrate()`.
 #' @return AUC value.
 #' @note
-#' Calculation of the area always begins from delay 0, where an indifference point of 1 is assumed.
+#' An indifference point of 1 is assumed at delay 0.
 #' @examples
 #' \dontrun{
 #' data("td_bc_single_ptpt")
@@ -107,10 +107,6 @@ AUC <- function(obj, min_del = 0, max_del = NULL, val_del = NULL, del_transform 
     # Model-based AUC
     stopifnot(inherits(obj, 'td_um'))
     max_del <- max_del %def% max(obj$data$del)
-    if (obj$config$discount_function$name == 'model-free') {
-      # Assume indiff = 1 at del = 0
-      obj$optim$par <- c(c('del_0' = 1), obj$optim$par)
-    }
     if (is.null(val_del)) {
       if ('val_del' %in% names(obj$data)) {
         val_del <- mean(obj$data$val_del)
@@ -186,10 +182,9 @@ nonsys <- function(obj) {
     if (obj$config$discount_function$name != 'model-free') {
       stop('Discount function must be "model-free" to check for non-systematic discounting.')
     } else {
-      cf <- coef(obj)
-      cf <- cf[grep('del_', names(cf))]
-      indiffs <- unname(cf)
-      delays <- as.numeric(gsub('del_', '', names(cf)))
+      data <- indiffs(obj)
+      indiffs <- data$indiff
+      delays <- data$del
     }
   } else {
     stop('Input must be a data.frame or a model of class td_bcnm, td_ipm, or td_ddm.')

--- a/R/td_bcnm.R
+++ b/R/td_bcnm.R
@@ -36,8 +36,6 @@ td_bcnm <- function(
     choice_rule = c('logistic', 'probit', 'power'),
     fixed_ends = F,
     fit_err_rate = F,
-    # robust = F,
-    # param_ranges = NULL,
     gamma_par_starts = c(0.01, 1, 100),
     eps_par_starts = c(0.01, 0.25),
     silent = T,
@@ -118,9 +116,10 @@ td_bcnm <- function(
   cand_mod <- list(data = data)
   class(cand_mod) <- c('td_bcnm', 'td_um')
   for (cand_fn in cand_fns) {
+    
+    cand_fn <- initialize_discount_function(cand_fn, data)
     config <- args
     config$discount_function <- cand_fn
-    
     cand_mod$config <- config
     
     # Get prob. model with the given settings but parameter values unspecified
@@ -137,11 +136,7 @@ td_bcnm <- function(
     }
     
     # Get parameter starting values
-    if (is.function(config$discount_function$par_starts)) {
-      par_starts <- config$discount_function$par_starts(data)
-    } else {
-      par_starts <- config$discount_function$par_starts
-    }
+    par_starts <- config$discount_function$par_starts
     # Add gamma start values
     par_starts <- c(
       par_starts,
@@ -160,11 +155,7 @@ td_bcnm <- function(
     }
     
     # Get parameter bounds
-    if (is.function(config$discount_function$par_lims)) {
-      par_lims <- config$discount_function$par_lims(data)
-    } else {
-      par_lims <- config$discount_function$par_lims
-    }
+    par_lims <- config$discount_function$par_lims
     # Add gamma limits
     par_lims <- c(
       par_lims,

--- a/R/td_ipm.R
+++ b/R/td_ipm.R
@@ -51,12 +51,6 @@ td_ipm <- function(
     optim_args = list(),
     silent = T) {
   
-  # Set discount function(s)
-  if ('all' %in% discount_function) {
-    # If "all" is used, replace discount_function with a vector of all the options
-    discount_function <- eval(formals(td_fn)$predefined)
-  }
-  
   # Required data columns
   validate_td_data(data, required_columns = c('indiff', 'del'))
   data <- na.action(data)
@@ -69,22 +63,15 @@ td_ipm <- function(
   class(cand_mod) <- c('td_ipm', 'td_um')
   for (cand_fn in cand_fns) {
    
+    # Initialize
+    cand_fn <- initialize_discount_function(cand_fn, data)
+    
     # Get residual sum of squares function
     rss_fn <- get_rss_fn(data, cand_fn$fn)
     
-    # Get parameter starting values
-    if (is.function(cand_fn$par_starts)) {
-      par_starts <- cand_fn$par_starts(data)
-    } else {
-      par_starts <- cand_fn$par_starts
-    }
-    
-    # Get parameter bounds
-    if (is.function(cand_fn$par_lims)) {
-      par_lims <- cand_fn$par_lims(data)
-    } else {
-      par_lims <- cand_fn$par_lims
-    }
+    # Get parameter starting values and bounds
+    par_starts <- cand_fn$par_starts
+    par_lims <- cand_fn$par_lims
     
     # Run optimization
     optimized <- run_optimization(rss_fn, par_starts, par_lims, optim_args = optim_args, silent = silent)

--- a/man/AUC.Rd
+++ b/man/AUC.Rd
@@ -33,7 +33,7 @@ AUC value.
 Compute either the model-based or model-free area under the curve.
 }
 \note{
-Calculation of the area always begins from delay 0, where an indifference point of 1 is assumed.
+An indifference point of 1 is assumed at delay 0.
 }
 \examples{
 \dontrun{

--- a/man/td_fn.Rd
+++ b/man/td_fn.Rd
@@ -8,10 +8,11 @@ td_fn(
   predefined = c("hyperbolic", "exponential", "power", "inverse-q-exponential",
     "nonlinear-time-hyperbolic", "scaled-exponential", "dual-systems-exponential",
     "nonlinear-time-exponential", "model-free", "constant"),
-  name = NULL,
+  name = "unnamed",
   fn = NULL,
   par_starts = NULL,
   par_lims = NULL,
+  init = NULL,
   ED50 = NULL,
   par_chk = NULL
 )
@@ -26,6 +27,8 @@ td_fn(
 \item{par_starts}{A named list of vectors, each specifying possible starting values for a parameter to try when running optimization.}
 
 \item{par_lims}{A named list of vectors, each specifying the bounds to impose of a parameters. Any parameter for which bounds are unspecified are assumed to be unbounded.}
+
+\item{init}{A function to initialize the td_fn object. It should take 2 arguments: "self" (the td_fn object being initialized) and "data" (the data used for initialization).}
 
 \item{ED50}{A function which, given a named vector of parameters \code{p} and optionally a value of \code{del_val}, computes the ED50. If there is no closed-form solution, this should return the string "non-analytic". If the ED50 is not well-defined, this should return the string "none". As a shortcut for these latter 2 cases, the strings "non-analytic" and "none" can be directly supplied as arguments.}
 
@@ -47,7 +50,7 @@ custom_discount_function <- td_fn(
   fn = function(data, p) (1 - p['b'])*exp(-p['k']*data$del) + p['b'],
   par_starts = list(k = c(0.001, 0.1), b = c(0.001, 0.1)),
   par_lims = list(k = c(0, Inf), b = c(0, 1)),
-  ED50 = function(...) 'non-analytic'
+  ED50 = 'non-analytic'
 )
 mod <- td_bcnm(td_bc_single_ptpt, discount_function = custom_discount_function, fit_err_rate = T)
 }

--- a/tests/testthat/test-td_ddm.R
+++ b/tests/testthat/test-td_ddm.R
@@ -65,10 +65,11 @@ test_that('multiple discount functions', {
     fn = function(data, p) (1 - p['b'])*exp(-p['k']*data$del) + p['b'],
     par_starts = list(k = c(0.001, 0.1), b = c(0.001, 0.1)),
     par_lims = list(k = c(0, Inf), b = c(0, 1)),
-    ED50 = function(p, ...) 'non-analytic'
+    ED50 = 'non-analytic'
   )
   args <- default_args
   args$discount_function <- list('model-free', 'dual-systems-exponential', custom_discount_function)
+  args$silent <- F
   expect_no_error(do.call(td_ddm, args))
 })
 


### PR DESCRIPTION
Previously, the correspondence between delays and indifference points was encoded in the names of the parameter vector. This wasn't great because it required storing floating point data in strings. Now the correspondence is established in an enclosing environment when an init() function is called.